### PR TITLE
Restrict version tagging to main branch with commits

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -39,14 +39,14 @@ jobs:
         release_name: Release ${{ steps.gitversion.outputs.MajorMinorPatch }}  
     - name: Update major version tag
       uses: richardsimko/update-tag@v1
-      if: needs.build.outputs.CommitsSinceVersionSource > 0 
+      if: needs.build.outputs.CommitsSinceVersionSource > 0 && github.ref == 'refs/heads/main'
       with:
         tag_name: "v${{ needs.build.outputs.Major }}"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Create Major version Release (update) #Create or Update the major version release. e.g. 'v2'
       uses: ncipollo/release-action@v1
-      if: needs.build.outputs.CommitsSinceVersionSource > 0 
+      if: needs.build.outputs.CommitsSinceVersionSource > 0 && github.ref == 'refs/heads/main' 
       with:
         tag: "v${{ needs.build.outputs.Major }}"
         name: "v${{ needs.build.outputs.Major }}"
@@ -54,14 +54,14 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }} 
     - name: Update minor version tag
       uses: richardsimko/update-tag@v1
-      if: needs.build.outputs.CommitsSinceVersionSource > 0 
+      if: needs.build.outputs.CommitsSinceVersionSource > 0 && github.ref == 'refs/heads/main' 
       with:
         tag_name: "v${{ needs.build.outputs.Major }}.${{ needs.build.outputs.Minor }}"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Create Minor version Release (update) #Create or Update the minor version release. e.g. 'v2.1'
       uses: ncipollo/release-action@v1
-      if: needs.build.outputs.CommitsSinceVersionSource > 0 
+      if: needs.build.outputs.CommitsSinceVersionSource > 0 && github.ref == 'refs/heads/main' 
       with:
         tag: "v${{ needs.build.outputs.Major }}.${{ needs.build.outputs.Minor }}"
         name: "v${{ needs.build.outputs.Major }}.${{ needs.build.outputs.Minor }}"


### PR DESCRIPTION
Updated conditions to check for commits and branch before tagging and releasing versions.